### PR TITLE
DbContextFactory added to services in startup

### DIFF
--- a/core/BlazorBuddies.Core/BlazorBuddies.Core.csproj
+++ b/core/BlazorBuddies.Core/BlazorBuddies.Core.csproj
@@ -8,4 +8,8 @@
     <Folder Include="Business\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/web/BlazorBuddies.Web/BlazorBuddies.Web.csproj
+++ b/web/BlazorBuddies.Web/BlazorBuddies.Web.csproj
@@ -1,7 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\BlazorBuddies.Core\BlazorBuddies.Core.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />  
+  </ItemGroup>
 
 </Project>

--- a/web/BlazorBuddies.Web/Startup.cs
+++ b/web/BlazorBuddies.Web/Startup.cs
@@ -1,3 +1,4 @@
+using BlazorBuddies.Core.Data;
 using BlazorBuddies.Web.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components;
@@ -6,6 +7,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +30,11 @@ namespace BlazorBuddies.Web
         {
             services.AddRazorPages();
             services.AddServerSideBlazor();
-            services.AddSingleton<WeatherForecastService>();
+
+            //Recommended approach is to create DbContexts in Blazor Server-Side using a DbContextFactory
+            services.AddDbContextFactory<BuddyDbContext>(opt => 
+                opt.UseSqlServer(Configuration.GetConnectionString("REPLACE WITH YOUR STRING NAME IN appsettings.json")));
+           
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Assuming you are using SqlServer I add the DbContextFactory to startup.cs in  BlazingBuddies.Web
DbContextFactory is a recommend approach when using EF core with Blazor server https://docs.microsoft.com/en-us/aspnet/core/blazor/blazor-server-ef-core?view=aspnetcore-5.0