### PR TITLE
fix: enable local SQL server for development

### DIFF
--- a/core/BlazorBuddies.Core/Common/Entities/Donor.cs
+++ b/core/BlazorBuddies.Core/Common/Entities/Donor.cs
@@ -1,21 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BlazorBuddies.Core.Common
 {
-    public class Donor
-    {
-        public Guid Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string EmailAddress { get; set; }
-        public string StreetAddress1 { get; set; }
-        public string StreetAddress2 { get; set; }
-        public string City { get; set; }
-        public string State { get; set; }
-        public string PostalCode { get; set; }
-        public Boolean OptOut { get; set; }
-        public string PhoneNumber { get; set; }
-    }
+	public class Donor
+	{
+		public Guid Id { get; set; }
+		public string FirstName { get; set; }
+		public string LastName { get; set; }
+		public string EmailAddress { get; set; }
+		public string StreetAddress1 { get; set; }
+		public string StreetAddress2 { get; set; }
+		public string City { get; set; }
+		public string State { get; set; }
+		public string PostalCode { get; set; }
+		public bool OptOut { get; set; }
+		public string PhoneNumber { get; set; }
+	}
 }

--- a/core/BlazorBuddies.Core/Common/Entities/School.cs
+++ b/core/BlazorBuddies.Core/Common/Entities/School.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BlazorBuddies.Core.Common
 {
-    public class School
-    {
-        public Guid Id { get; set; }
-        public string Name { get; set; }
-        public string City { get; set; }
-        public int Buddies { get; set; }
-    }
+	public class School
+	{
+		public Guid Id { get; set; }
+		public string Name { get; set; }
+		public string City { get; set; }
+		public int Buddies { get; set; }
+	}
 }

--- a/core/BlazorBuddies.Core/Common/EntityFactory.cs
+++ b/core/BlazorBuddies.Core/Common/EntityFactory.cs
@@ -2,32 +2,33 @@
 
 namespace BlazorBuddies.Core.Common
 {
-  public static class EntityFactory
-  {
-		public static School CreateSchool(string Name, string City, int Buddies)
+	public static class EntityFactory
+	{
+		public static School CreateSchool(string name, string city, int buddies)
 		{
-				return new School() {
-					Id = Guid.NewGuid(),
-					Name = Name,
-					City = City,
-					Buddies = Buddies
-				};
+			return new School {
+				Id = Guid.NewGuid(),
+				Name = name,
+				City = city,
+				Buddies = buddies
+			};
 		}
 
-		public static Donor CreateDonor(string FirstName, string LastName, string EmailAddress, string StreetAddress1, string StreetAddress2, string City, string State, string PostalCode, string PhoneNumber, bool OptOut)
+		public static Donor CreateDonor(string firstName, string lastName, string emailAddress, string streetAddress1, string streetAddress2, string city,
+			string state, string postalCode, string phoneNumber, bool optOut)
 		{
-			return new Donor() {
+			return new Donor {
 				Id = Guid.NewGuid(),
-				FirstName = FirstName,
-				LastName = LastName,
-				EmailAddress = EmailAddress,
-				StreetAddress1 = StreetAddress1,
-				StreetAddress2 = StreetAddress2,
-				City = City,
-				State = State,
-				PostalCode = PostalCode,
-				PhoneNumber = PhoneNumber,
-				OptOut = OptOut
+				FirstName = firstName,
+				LastName = lastName,
+				EmailAddress = emailAddress,
+				StreetAddress1 = streetAddress1,
+				StreetAddress2 = streetAddress2,
+				City = city,
+				State = state,
+				PostalCode = postalCode,
+				PhoneNumber = phoneNumber,
+				OptOut = optOut
 			};
 		}
 	}

--- a/web/BlazorBuddies.Web/Extensions/IApplicationBuilderExtensions.cs
+++ b/web/BlazorBuddies.Web/Extensions/IApplicationBuilderExtensions.cs
@@ -1,28 +1,33 @@
-﻿using BlazorBuddies.Core.Common;
+﻿using System;
+using System.Linq;
+
+using BlazorBuddies.Core.Common;
 using BlazorBuddies.Core.Data;
 using BlazorBuddies.Web.States;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace BlazorBuddies.Web.Extensions
 {
-	static internal class IApplicationBuilderExtensions
+	internal static class IApplicationBuilderExtensions
 	{
-		static internal IApplicationBuilder InitAppState(this IApplicationBuilder builder)
+		internal static IApplicationBuilder InitAppState(this IApplicationBuilder builder)
 		{
 			var state = builder.ApplicationServices.GetRequiredService<ApplicationState>();
 			var dbContextFactory = builder.ApplicationServices.GetRequiredService<IDbContextFactory<BuddyDbContext>>();
 			using var dbContext = dbContextFactory.CreateDbContext();
+
 #if DEBUG
+			// TODO: Move this to a proper seeding factory.
+			// https://docs.microsoft.com/en-us/ef/core/modeling/data-seeding
 			// Let's make sure our database is always up-to-date while developing
+
 			if (dbContext.Database.GetPendingMigrations().Any()) {
 				dbContext.Database.Migrate();
 			}
+
 			// Let's include at least one school with buddies while developing
 			if (!dbContext.Schools.Any()) {
 				dbContext.Schools.Add(new School {
@@ -34,6 +39,7 @@ namespace BlazorBuddies.Web.Extensions
 				dbContext.SaveChanges();
 			}
 #endif
+
 			state.BuddyCount = dbContext.Schools.Sum(s => s.Buddies);
 			return builder;
 		}

--- a/web/BlazorBuddies.Web/Program.cs
+++ b/web/BlazorBuddies.Web/Program.cs
@@ -4,17 +4,23 @@ using Microsoft.Extensions.Hosting;
 
 namespace BlazorBuddies.Web
 {
-    public class Program
-    {
-        public static void Main(string[] args) => CreateHostBuilder(args).Build().Run();
+	public class Program
+	{
+		public static void Main(string[] args)
+		{
+			CreateHostBuilder(args).Build().Run();
+		}
 
-        public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((hostContext, builder) => {
-                // Adds vars for user-secrets
-                if (hostContext.HostingEnvironment.IsDevelopment()) {
-                    builder.AddUserSecrets<Program>();
-                }
-            })
-            .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
-    }
+		public static IHostBuilder CreateHostBuilder(string[] args)
+		{
+			return Host.CreateDefaultBuilder(args)
+			           .ConfigureAppConfiguration((hostContext, builder) => {
+				           // Adds vars for user-secrets
+				           if (hostContext.HostingEnvironment.IsDevelopment()) {
+					           builder.AddUserSecrets<Program>();
+				           }
+			           })
+			           .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
+		}
+	}
 }

--- a/web/BlazorBuddies.Web/appsettings.Development.json
+++ b/web/BlazorBuddies.Web/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "BuddyDb": "Server=tcp:bpbdev.database.windows.net,1433;Initial Catalog=buddy;Persist Security Info=False;User ID=bpbuser;Password=ooll0VILD-voc;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "BuddyDb": "Server=(localdb)\\mssqllocaldb;Database=buddy;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "DetailedErrors": true,
   "Logging": {

--- a/web/BlazorBuddies.Web/appsettings.json
+++ b/web/BlazorBuddies.Web/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "BuddyDb": "Server=tcp:bpbdev.database.windows.net,1433;Initial Catalog=buddy;Persist Security Info=False;User ID=bpbuser;Password=ooll0VILD-voc;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Enable a local SQL server for development purposes. This allows other developers to actually help out with this project without needing to be whitelisted by the main production database in Azure.
