### PR TITLE
feat(api): enable API controllers and remove manual startup registration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,9 @@ end_of_line = lf
 
 #use soft tabs (spaces) for indentation
 indent_style = tab
-indent_size = 2;
+
+# While 2 spaces works well for streaming, it really doesn't work well for normal development or IDEs that do virtual tabs (ReSharper, CodeRush, etc)
+indent_size = 4;
 
 #Formatting - new line options
 
@@ -88,7 +90,8 @@ dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggest
 #Style - Modifier preferences
 
 #when this rule is set to a list of modifiers, prefer the specified ordering.
-csharp_preferred_modifier_order = public,private,static,readonly:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
 
 #Style - qualification options
 

--- a/web/BlazorBuddies.Web/BlazorBuddies.Web.csproj
+++ b/web/BlazorBuddies.Web/BlazorBuddies.Web.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Web" Version="1.3.0" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.3.0" />
-    <PackageReference Include="vonage" Version="5.6.0" />  
+    <PackageReference Include="vonage" Version="5.5.0" />  
   </ItemGroup>
 
   <ItemGroup>
@@ -52,10 +52,6 @@
 
   <ItemGroup>
     <Content Include="Admin\NavBar.razor.css" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="NewFolder\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/web/BlazorBuddies.Web/Controllers/CountController.cs
+++ b/web/BlazorBuddies.Web/Controllers/CountController.cs
@@ -1,0 +1,40 @@
+﻿using BlazorBuddies.Web.States;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BlazorBuddies.Web.Controllers
+{
+	// This should really be api/count but just to keep the same route
+	// This is what we'll use.
+	[Route("count")]
+	[ApiController]
+#if DEBUG
+
+	// Only in debug should this be anonymous. It's just for testing the counter object on the page.
+	[AllowAnonymous]
+#endif
+	public class CountController : ControllerBase
+	{
+		private readonly ApplicationState _appState;
+
+		/// <inheritdoc />
+		public CountController(ApplicationState appState)
+		{
+			_appState = appState;
+		}
+
+		[HttpGet]
+		public int Get()
+		{
+			return _appState.BuddyCount;
+		}
+
+		// This should *really* be a POST, but since it's just for debugging, we'll leave it as a get.
+		[HttpGet("{count}")]
+		public void Set(int count)
+		{
+			_appState.BuddyCount = count;
+		}
+	}
+}

--- a/web/BlazorBuddies.Web/Controllers/Webhooks/DeliveryReceiptController.cs
+++ b/web/BlazorBuddies.Web/Controllers/Webhooks/DeliveryReceiptController.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+
+using Vonage.Messaging;
+using Vonage.Utility;
+
+namespace BlazorBuddies.Web.Controllers.Webhooks
+{
+	[Route("webhooks/dlr")]
+	[ApiController]
+	public class DeliveryReceiptController : ControllerBase
+	{
+		private readonly DonorService _donorService;
+
+		/// <inheritdoc />
+		public DeliveryReceiptController(DonorService donorService)
+		{
+			_donorService = donorService;
+		}
+
+		[HttpGet]
+		public Task GetAsync()
+		{
+			var dlr = WebhookParser.ParseQuery<DeliveryReceipt>(HttpContext.Request.Query);
+			return _donorService.HandleDlr(dlr);
+		}
+	}
+}

--- a/web/BlazorBuddies.Web/Controllers/Webhooks/DeliveryReceiptController.cs
+++ b/web/BlazorBuddies.Web/Controllers/Webhooks/DeliveryReceiptController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Vonage.Messaging;
@@ -9,6 +10,7 @@ namespace BlazorBuddies.Web.Controllers.Webhooks
 {
 	[Route("webhooks/dlr")]
 	[ApiController]
+	[AllowAnonymous] // TODO: Look into authenticated requests on these endpoints. We don't need random requests coming from unknown locations.
 	public class DeliveryReceiptController : ControllerBase
 	{
 		private readonly DonorService _donorService;
@@ -24,6 +26,17 @@ namespace BlazorBuddies.Web.Controllers.Webhooks
 		{
 			var dlr = WebhookParser.ParseQuery<DeliveryReceipt>(HttpContext.Request.Query);
 			return _donorService.HandleDlr(dlr);
+		}
+
+		[HttpPost]
+		public async Task PostAsync()
+		{
+			// Personally, I don't like just blindly passing the body of the request to be parsed here. It makes integration testing difficult.
+			// Newtonsoft JSON is also many many times slower than the new System.Text.JsonSerializer.
+			// However, this is what's documented in the Vonage SDK, so this is what we'll use.
+			// https://github.com/Vonage/vonage-dotnet-sdk#post-2
+			var dlr = await WebhookParser.ParseWebhookAsync<DeliveryReceipt>(Request.Body, Request.ContentType);
+			await _donorService.HandleDlr(dlr);
 		}
 	}
 }

--- a/web/BlazorBuddies.Web/DonorService.cs
+++ b/web/BlazorBuddies.Web/DonorService.cs
@@ -1,30 +1,34 @@
-﻿using BlazorBuddies.Core.Data;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Vonage.Messaging;
-using Microsoft.EntityFrameworkCore;
-using Vonage;
-using Microsoft.Extensions.Configuration;
+
 using BlazorBuddies.Core.Common;
-using Microsoft.AspNetCore.SignalR;
+using BlazorBuddies.Core.Data;
 using BlazorBuddies.Web.Hubs;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+using Vonage;
+using Vonage.Messaging;
+
 namespace BlazorBuddies.Web
 {
-  public class DonorService
-  {
-		private readonly BuddyDbContext _db;
+	public class DonorService
+	{
 		private readonly VonageClient _client;
 		private readonly IConfiguration _config;
+		private readonly BuddyDbContext _db;
 		private readonly IHubContext<DonorHub> _hub;
 
 		public DonorService(BuddyDbContext db, VonageClient client, IConfiguration config, IHubContext<DonorHub> hub)
 		{
-				_db = db;
-				_client = client;
-				_config = config;
-				_hub = hub;
+			_db = db;
+			_client = client;
+			_config = config;
+			_hub = hub;
 		}
 
 		//TODO: Add pagination
@@ -35,19 +39,17 @@ namespace BlazorBuddies.Web
 
 		public async Task HandleDlr(DeliveryReceipt dlr)
 		{
-			var donors = (await _db.Donors.Where(x => x.PhoneNumber == dlr.Msisdn)
-				.ToListAsync())
-				.ToDonorModels()
-				.ToList();
+			var donors = (await _db.Donors.Where(x => x.PhoneNumber == dlr.Msisdn).ToListAsync()).ToDonorModels().ToList();
 			donors.ForEach(d => {
-				if(dlr.Status == DlrStatus.failed || dlr.Status == DlrStatus.rejected) {
+				if ((dlr.Status == DlrStatus.failed) || (dlr.Status == DlrStatus.rejected)) {
 					d.NumberReachable = false;
 					d.ContactSuccessful = false;
-			  }
-			  else {
+				}
+				else {
 					d.ContactSuccessful = true;
-			  }				
+				}
 			});
+
 			//foreach(var d in donors) {
 			//	await _hub.SendDonor(d);
 			//}
@@ -63,11 +65,10 @@ namespace BlazorBuddies.Web
 			}
 		}
 
-		public async Task ContactDonors(IEnumerable<Guid> userIds, string message) 
+		public async Task ContactDonors(IEnumerable<Guid> userIds, string message)
 		{
-			var donors = await _db.Donors.Where(d => userIds.Any(x=>x==d.Id) && !d.OptOut && d.NumberReachable).ToListAsync();
-			foreach(var donor in donors) 
-			{
+			var donors = await _db.Donors.Where(d => userIds.Any(x => x == d.Id) && !d.OptOut && d.NumberReachable).ToListAsync();
+			foreach (var donor in donors) {
 				var msg = new SendSmsRequest {
 					To = donor.PhoneNumber,
 					From = _config["VONAGE_NUMBER"],
@@ -77,5 +78,5 @@ namespace BlazorBuddies.Web
 				await Task.Delay(1000);
 			}
 		}
-  }
+	}
 }

--- a/web/BlazorBuddies.Web/Hubs/DonorHub.cs
+++ b/web/BlazorBuddies.Web/Hubs/DonorHub.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.SignalR;
 
 namespace BlazorBuddies.Web.Hubs
 {
-  public class DonorHub : Hub 
+	public class DonorHub : Hub
 	{
 		public async Task SendDonor(DonorModel donor)
 		{


### PR DESCRIPTION
Enable API controllers using the standard ASP.NET Web API controllers.

Fixed some formatting rules in the editorconfig that tend to break IDEs. (2 space tabs, modifier order)

Small cleanup.